### PR TITLE
Set default git provider if set

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -186,7 +186,7 @@ action_name:
 ci_type:
   help: CI type
   type: str
-  default: github
+  default: "{% if git_provider %}{{ git_provider }}{% else %}gitlab{% endif %}"
   choices: [github, gitlab]
   when: "{{ 'ci' in template }}"
 


### PR DESCRIPTION
This pull request ensures the git_provider default argument is used if the value is set.

Depends on https://github.com/tu-darmstadt-ros-pkg/tuda_workspace_scripts/pull/20